### PR TITLE
replace args with command in template and add ServiceAccount

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -59,7 +59,7 @@ objects:
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           command:
-          - rosa-mcp-server
+          - /app/rosa-mcp-server
           - --transport=sse
           - --host=${HOST}
           - --port=${PORT}

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -58,7 +58,8 @@ objects:
         - name: rosa-mcp-server
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
-          args:
+          command:
+          - rosa-mcp-server
           - --transport=sse
           - --host=${HOST}
           - --port=${PORT}

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -30,6 +30,12 @@ parameters:
     value: rosa-mcp-server.example.com
     description: "Hostname for the OpenShift route"
 objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: rosa-mcp-server
+    labels:
+      app: rosa-mcp-server
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -54,6 +60,7 @@ objects:
         labels:
           app: rosa-mcp-server
       spec:
+        serviceAccountName: rosa-mcp-server
         containers:
         - name: rosa-mcp-server
           image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
use `command` to fix this error:
```
Error: container create failed: executable file `--transport=sse` not found in $PATH: No such file or directory
```

add ServiceAccount to be able to assume role into other aws accounts.
this PR depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/152945
this PR is a dependency for https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/152944