### PR TITLE
Add prompt providing a workflow for ROSA HCP Cluster pre-req guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ Flags:
   --transport string      transport mode (stdio/sse) (default "stdio")
 ```
 
-### Environment Variables
-
-- `OCM_OFFLINE_TOKEN`: Your OCM offline token for authentication - only used in stdio transport
-
 ### TOML Configuration File
 
 ```toml
@@ -81,6 +77,8 @@ sse_base_url = "https://example.com:8080"
 
 ### Stdio Transport (Local)
 
+Stdio transport requires the `OCM_OFFLINE_TOKEN` environment variable for authentication.
+
 ```bash
 # Set your OCM token
 export OCM_OFFLINE_TOKEN="your-ocm-token-here"
@@ -91,6 +89,8 @@ export OCM_OFFLINE_TOKEN="your-ocm-token-here"
 
 ### SSE Transport (Remote)
 
+SSE transport uses header-based authentication with the `X-OCM-OFFLINE-TOKEN` header. No environment variables required.
+
 ```bash
 # Start SSE server
 ./rosa-mcp-server --transport=sse --port=8080
@@ -98,7 +98,7 @@ export OCM_OFFLINE_TOKEN="your-ocm-token-here"
 # Server will be available at:
 # - SSE stream: http://localhost:8080/sse
 # - MCP messages: http://localhost:8080/message
-# Send X-OCM-OFFLINE-TOKEN header with requests
+# Authentication: Send X-OCM-OFFLINE-TOKEN header with requests
 ```
 
 ## Authentication Setup
@@ -264,7 +264,9 @@ make undeploy           # Remove from OpenShift
 
 ## Integration with AI Assistants
 
-Add to your mcpServers list:
+### Stdio Transport Configuration
+
+For local stdio-based integration:
 
 ```json
 {
@@ -280,19 +282,21 @@ Add to your mcpServers list:
 }
 ```
 
-### SSE Integration
+### SSE Transport Configuration
 
-For remote integrations, use the SSE endpoints:
+For remote SSE-based integration (no environment variables needed):
 
-```bash
-# SSE stream endpoint (for Server-Sent Events)
-GET http://localhost:8080/sse
-
-# MCP message endpoint (for sending JSON-RPC messages)
-POST http://localhost:8080/message
-
-# Required header for both endpoints
-X-OCM-OFFLINE-TOKEN: your-token-here
+```json
+{
+  "mcpServers": {
+    "rosa-hcp": {
+      "url": "http://your-server:8080/sse",
+      "headers": {
+        "X-OCM-OFFLINE-TOKEN": "your-token-here"
+      }
+    }
+  }
+}
 ```
 
 ## Error Handling

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+//go:embed prompts/rosa-hcp-prerequisites-guide.md
+var prereqsGuide string
+
+// registerPrompts registers all MCP prompts with the server
+func (s *Server) registerPrompts() {
+	// ROSA HCP Prerequisites Guide prompt
+	s.mcpServer.AddPrompt(mcp.NewPrompt("rosa_hcp_prerequisites_guide",
+		mcp.WithPromptDescription("Comprehensive guidance on ROSA HCP cluster creation prerequisites and setup steps"),
+	), s.handleROSAHCPPrereqsPrompt)
+}
+
+// handleROSAHCPPrereqsPrompt provides comprehensive ROSA HCP prerequisites guidance as a prompt
+func (s *Server) handleROSAHCPPrereqsPrompt(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	return mcp.NewGetPromptResult(
+		"ROSA HCP Prerequisites Guide",
+		[]mcp.PromptMessage{
+			mcp.NewPromptMessage(
+				mcp.RoleUser,
+				mcp.NewTextContent(prereqsGuide),
+			),
+			mcp.NewPromptMessage(
+				mcp.RoleUser,
+				mcp.NewResourceLink(
+					"https://cloud.redhat.com/learning/learn:getting-started-red-hat-openshift-service-aws-rosa/resource/resources:creating-rosa-hcp-clusters-using-default-options#page-title",
+					"ROSA HCP Documentation",
+					"Official Red Hat documentation for creating ROSA HCP clusters using default options",
+					"text/html",
+				),
+			),
+		},
+	), nil
+}

--- a/pkg/mcp/prompts/rosa-hcp-prerequisites-guide.md
+++ b/pkg/mcp/prompts/rosa-hcp-prerequisites-guide.md
@@ -1,0 +1,369 @@
+# ROSA HCP Prerequisites Assistant Instructions
+
+You are guiding a user through the complete setup process for creating a ROSA HCP (Red Hat OpenShift Service on AWS with Hosted Control Planes) cluster. ROSA with HCP offers a more efficient and reliable architecture where each cluster has a dedicated control plane isolated in a ROSA service account.
+
+**CRITICAL**: It is not possible to upgrade or convert existing ROSA "Classic" clusters to hosted control planes architecture - users must create a new cluster to use ROSA with HCP functionality.
+
+**VPC SHARING LIMITATION**: Sharing VPCs across multiple AWS accounts is not currently supported for ROSA with HCP. Do not install a ROSA with HCP cluster into subnets shared from another AWS account.
+
+## Your Role
+
+Help the user complete all prerequisites for ROSA HCP cluster creation, then guide them to use the `create_rosa_hcp_cluster` MCP tool with the correct parameters. Be thorough, ask for confirmation at each step, collect all required values, and answer any questions they have about each step.
+
+## Prerequisites Overview
+
+To create a ROSA with HCP cluster, the user must have:
+1. A configured Virtual Private Cloud (VPC)
+2. Account-wide roles
+3. An OIDC configuration
+4. Operator roles
+
+## Prerequisites Workflow
+
+### Step 1: Initial Verification and Setup
+
+First, verify the user has completed AWS prerequisites for ROSA with HCP:
+
+**Required Tools and Access:**
+- **AWS CLI**: Installed and configured with appropriate credentials
+- **ROSA CLI**: Latest version installed (`rosa version` to check current version)
+- **Red Hat Account**: Must be logged in via ROSA CLI (`rosa login`)
+- **Available AWS service quotas**: Sufficient quotas for the intended cluster size
+- **ROSA service enabled**: Must be enabled in the AWS Console
+- **AWS Elastic Load Balancing (ELB) service role**: Must exist in their AWS account
+
+**Ask the user to confirm each item before proceeding. If they need help with any item, provide specific guidance.**
+
+**Additional Context for Questions:**
+- The ROSA CLI can be updated if a newer version is available - the CLI will provide a download link
+- AWS service quotas can be checked in the AWS Console under Service Quotas
+- The ELB service role is typically created automatically but may need manual creation in some cases
+
+### Step 2: Virtual Private Cloud (VPC) Creation
+
+**CRITICAL**: A properly configured VPC is mandatory for ROSA with HCP clusters. The user has two options:
+
+#### Option A: Terraform VPC (Recommended for Testing and Demonstration)
+
+**Important Notes for Users:**
+- The Terraform instructions are for testing and demonstration purposes
+- Production installations require modifications to the VPC for specific use cases
+- Ensure the Terraform script runs in the same region where they intend to install their cluster
+- Examples use `us-east-2` but they can choose their preferred region
+
+**Prerequisites for Terraform Option:**
+- Terraform version 1.4.0 or newer installed
+- Git installed on their machine
+
+**Step-by-step Terraform Process:**
+
+1. **Clone the Terraform VPC repository:**
+   ```bash
+   git clone https://github.com/openshift-cs/terraform-vpc-example
+   cd terraform-vpc-example
+   ```
+
+2. **Initialize Terraform:**
+   ```bash
+   terraform init
+   ```
+   A message confirming initialization will appear when complete.
+
+3. **Create the Terraform plan:**
+   ```bash
+   terraform plan -out rosa.tfplan -var region=<their_region>
+   ```
+   - Ask for their AWS region preference
+   - They can optionally specify a cluster name
+   - A `rosa.tfplan` file will be added to the directory after completion
+   - Refer them to the [Terraform VPC repository's README](https://github.com/openshift-cs/terraform-vpc-example/blob/main/README.md) for detailed options
+
+4. **Apply the plan to build the VPC:**
+   ```bash
+   terraform apply rosa.tfplan
+   ```
+
+5. **Capture subnet IDs for cluster creation:**
+   ```bash
+   export SUBNET_IDS=$(terraform output -raw cluster-subnets-string)
+   echo $SUBNET_IDS
+   ```
+   **COLLECT AND SAVE**: Record these subnet IDs - they're needed for the `subnet_ids` parameter.
+
+6. **Verify the variable was set correctly:**
+   ```bash
+   echo $SUBNET_IDS
+   ```
+
+**Additional Context**: The [Terraform VPC repository](https://github.com/openshift-cs/terraform-vpc-example) provides a detailed list of all customization options available.
+
+#### Option B: Manual VPC Creation
+
+If the user chooses manual VPC creation:
+
+1. **Direct them to create VPC**: [AWS VPC Console](https://us-east-1.console.aws.amazon.com/vpc/)
+
+2. **CRITICAL VPC Subnet Tagging Requirements:**
+   After VPC creation, subnets MUST be tagged correctly. Automated service preflight checks verify these tags before allowing cluster creation.
+
+   **Required Tags:**
+   - **Public subnets**: `kubernetes.io/role/elb` with value `1` (or no value)
+   - **Private subnets**: `kubernetes.io/role/internal-elb` with value `1` (or no value)
+
+   **IMPORTANT**: They must tag at least one private subnet and one public subnet (if applicable).
+
+3. **Tagging Commands:**
+   ```bash
+   # For public subnets:
+   aws ec2 create-tags --resources <public-subnet-id> --tags Key=kubernetes.io/role/elb,Value=1
+   
+   # For private subnets:
+   aws ec2 create-tags --resources <private-subnet-id> --tags Key=kubernetes.io/role/internal-elb,Value=1
+   ```
+
+4. **Verify tags are correctly applied:**
+   ```bash
+   aws ec2 describe-tags --filters "Name=resource-id,Values=<subnet_id>"
+   ```
+
+   **Example output:**
+   ```
+   TAGS    Name                    <subnet-id>     subnet  <prefix>-subnet-public1-us-east-1a
+   TAGS    kubernetes.io/role/elb  <subnet-id>     subnet  1
+   ```
+
+**COLLECT**: All subnet IDs and their corresponding availability zones for the `subnet_ids` and `availability_zones` parameters.
+
+### Step 3: Create Account-Wide STS Roles and Policies
+
+**Context**: These are AWS IAM roles required for ROSA with HCP operations. They need to be created once per AWS account.
+
+**Prerequisites Verification:**
+- Completed AWS prerequisites for ROSA with HCP
+- Available AWS service quotas
+- ROSA service enabled in AWS Console
+- Latest ROSA CLI installed and configured
+- Logged into Red Hat account via ROSA CLI
+
+**Process:**
+
+1. **Create account-wide roles:**
+   ```bash
+   rosa create account-roles --hosted-cp
+   ```
+   **IMPORTANT**: The `--hosted-cp` flag is required for ROSA with HCP clusters.
+
+2. **Optional - Set prefix as environment variable:**
+   ```bash
+   export ACCOUNT_ROLES_PREFIX=<account_role_prefix>
+   echo $ACCOUNT_ROLES_PREFIX
+   ```
+
+**Account Roles Created:**
+The command creates these specific roles (help user identify them):
+- **ManagedOpenShift-Installer-Role** → use for `role_arn` parameter
+- **ManagedOpenShift-Support-Role** → use for `support_role_arn` parameter
+- **ManagedOpenShift-Worker-Role** → use for `worker_role_arn` parameter
+- **ManagedOpenShift-User-Role** → use for `rosa_creator_arn` parameter
+
+**Help them find ARN values:**
+- List roles: `rosa list account-roles`
+- Get specific role details: `aws iam get-role --role-name <role-name>`
+
+**COLLECT**: All four role ARNs for the cluster creation parameters.
+
+**Additional Context**: Refer to [AWS managed IAM policies for ROSA](https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html) for detailed policy information.
+
+### Step 4: Create OpenID Connect (OIDC) Configuration
+
+**Context**: For ROSA with HCP clusters, the OIDC configuration must be created prior to cluster creation. This configuration is registered with OpenShift Cluster Manager.
+
+**Prerequisites:**
+- Completed AWS prerequisites for ROSA with HCP
+- Completed AWS prerequisites for Red Hat OpenShift Service on AWS
+- Latest ROSA CLI installed and configured
+
+**Process:**
+
+1. **Create OIDC configuration:**
+   ```bash
+   rosa create oidc-config --mode=auto --yes
+   ```
+
+   **Mode Options:**
+   - `--mode=auto`: Creates AWS resources automatically and provides OIDC config ID
+   - `--mode=manual`: Requires manual AWS CLI commands to determine values
+
+2. **Capture the OIDC Configuration ID:**
+   The CLI output provides the OIDC config ID - this is REQUIRED for cluster creation.
+
+3. **Optional - Save as environment variable:**
+   ```bash
+   export OIDC_ID=<oidc_config_id>
+   echo $OIDC_ID
+   ```
+
+4. **List available OIDC configurations:**
+   ```bash
+   rosa list oidc-config
+   ```
+   This shows all OIDC configurations associated with their user organization.
+
+**COLLECT**: The OIDC Configuration ID for the `oidc_config_id` parameter.
+
+### Step 5: Create Operator Roles and Policies
+
+**Context**: ROSA with HCP clusters require specific Operator IAM roles for cluster operations like managing backend storage, cloud provider credentials, and external cluster access. These roles use temporary permissions to carry out cluster operations.
+
+**Prerequisites:**
+- Completed AWS prerequisites for ROSA with HCP
+- Latest ROSA CLI installed and configured
+- Created account-wide AWS roles
+- Have OIDC configuration ID
+
+**Process:**
+
+1. **Choose and set prefix name:**
+   ```bash
+   export OPERATOR_ROLES_PREFIX=<their_chosen_prefix>
+   ```
+   **CRITICAL**: They MUST supply a prefix when creating Operator roles - failing to do so produces an error.
+
+2. **Create Operator roles (basic command):**
+   ```bash
+   rosa create operator-roles --hosted-cp
+   ```
+
+3. **Create Operator roles (full command with all parameters):**
+   ```bash
+   rosa create operator-roles --hosted-cp \
+     --prefix=$OPERATOR_ROLES_PREFIX \
+     --oidc-config-id=$OIDC_ID \
+     --installer-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role
+   ```
+
+   **Parameter Breakdown:**
+   - `--hosted-cp`: REQUIRED for ROSA with HCP clusters
+   - `--prefix=$OPERATOR_ROLES_PREFIX`: The prefix they chose
+   - `--oidc-config-id=$OIDC_ID`: OIDC configuration ID from previous step
+   - `--installer-role-arn`: Installer role ARN from account roles creation
+
+4. **List created Operator roles:**
+   ```bash
+   rosa list operator-roles
+   ```
+   This displays all prefixes associated with their AWS account and shows how many roles are associated with each prefix. They can choose to see detailed role information.
+
+**COLLECT**: The operator roles prefix for the `operator_role_prefix` parameter.
+
+### Step 6: Gather Additional Required Information
+
+**Collect the following information:**
+
+1. **Cluster name**: Ask what they want to name their cluster
+   - If longer than 15 characters, it will contain an autogenerated domain prefix
+   - They can customize the subdomain with `--domain-prefix` flag
+   - Domain prefix cannot be longer than 15 characters, must be unique, and cannot be changed after creation
+
+2. **AWS Account ID**: Help them get this:
+   ```bash
+   aws sts get-caller-identity
+   ```
+
+3. **Billing Account ID**: Usually same as AWS account ID
+
+4. **AWS Region**: Confirm their preferred region (default is us-east-1)
+
+5. **Private vs Public cluster**: Ask if they want a private cluster
+   - Private clusters use `--private` argument
+   - If private, only use private subnet IDs for `--subnet-ids`
+
+6. **Machine CIDR**: Ask about their VPC CIDR
+   - Default machine CIDR is 10.0.0.0/16
+   - If their VPC uses different CIDR, they'll need `--machine-cidr <address_block>`
+
+### Step 7: Parameter Validation and Review
+
+Before calling the MCP tool, review ALL collected parameters:
+
+**Required String Parameters:**
+- **cluster_name**: [confirm value]
+- **aws_account_id**: [confirm from aws sts get-caller-identity]
+- **billing_account_id**: [confirm - usually same as AWS account ID]
+- **role_arn**: [confirm ManagedOpenShift-Installer-Role ARN]
+- **operator_role_prefix**: [confirm prefix used in step 5]
+- **oidc_config_id**: [confirm ID from step 4]
+- **support_role_arn**: [confirm ManagedOpenShift-Support-Role ARN]
+- **worker_role_arn**: [confirm ManagedOpenShift-Worker-Role ARN]
+- **rosa_creator_arn**: [confirm ManagedOpenShift-User-Role ARN]
+
+**Required Array Parameters:**
+- **subnet_ids**: [confirm array of subnet IDs from VPC setup]
+- **availability_zones**: [confirm array of AZs corresponding to subnets]
+
+**Optional Parameters:**
+- **region**: [confirm region, default us-east-1]
+- **multi_arch_enabled**: [ask if they need multi-architecture support, default false]
+
+### Step 8: Create Cluster Using MCP Tool
+
+Once all parameters are confirmed and validated, use the `create_rosa_hcp_cluster` MCP tool with all collected values.
+
+**Remind the user**: If they specified custom ARN paths when creating account-wide roles, the custom path is automatically detected and applied to cluster-specific Operator roles.
+
+## After Cluster Creation
+
+Guide them through monitoring the cluster creation:
+
+1. **Check cluster status:**
+   ```bash
+   rosa describe cluster --cluster=<cluster_name>
+   ```
+
+   **State field progression:**
+   - `pending` (Preparing account)
+   - `installing` (DNS setup in progress)
+   - `installing`
+   - `ready`
+
+2. **Monitor installation logs:**
+   ```bash
+   rosa logs install --cluster=<cluster_name> --watch
+   ```
+   The `--watch` argument shows new log messages as installation progresses.
+
+3. **Use MCP tools for monitoring:**
+   - Use `get_cluster` MCP tool to check status programmatically
+   - Use `get_clusters` with state filter to see cluster in context
+
+## Troubleshooting
+
+**Installation Issues:**
+- If installation fails or State field doesn't change to ready after 10+ minutes, refer to [Troubleshooting installations](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/latest/html-single/support/index#rosa-troubleshooting-installing_rosa-troubleshooting-installations)
+- For Red Hat Support assistance: [Getting support for Red Hat OpenShift Service on AWS](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/latest/html-single/support/index#support_getting-support)
+
+**Common Issues:**
+- VPC subnet tagging is the most common issue
+- Ensure account-roles are created before operator-roles
+- OIDC config ID is required and must be created beforehand
+- Check AWS service quotas before attempting cluster creation
+
+## Additional Resources
+
+**Other ROSA with HCP Installation Options:**
+- [Creating a ROSA cluster using Terraform](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/latest/html/install_rosa_with_hcp_clusters/creating-a-rosa-cluster-using-terraform)
+- [Creating ROSA with HCP clusters using a custom AWS KMS encryption key](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/latest/html/install_rosa_with_hcp_clusters/rosa-hcp-creating-cluster-with-aws-kms-key)
+- [Creating a private cluster on ROSA with HCP](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/latest/html/install_rosa_with_hcp_clusters/rosa-hcp-aws-private-creating-cluster)
+- [Creating ROSA with HCP clusters with external authentication](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/latest/html/install_rosa_with_hcp_clusters/rosa-hcp-sts-creating-a-cluster-ext-auth)
+
+**Support Options:**
+- [Troubleshoot with Red Hat support](https://access.redhat.com/support/cases/#/case/new/open-case?intcmp=hp|a|a3|case&caseCreate=true)
+- [Troubleshoot with AWS support](https://docs.aws.amazon.com/ROSA/latest/userguide/troubleshooting-rosa.html)
+
+## Reference Documentation
+
+Direct users to the official guide: https://cloud.redhat.com/learning/learn:getting-started-red-hat-openshift-service-aws-rosa/resource/resources:creating-rosa-hcp-clusters-using-default-options
+
+## Instructions Summary
+
+Be systematic, confirm each step, collect all required parameters, and be ready to answer detailed questions about any aspect of the process. The user may ask about AWS prerequisites, VPC configuration, IAM roles, OIDC setup, or troubleshooting - use the context provided above to give comprehensive answers.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -33,6 +33,7 @@ func NewServer(cfg *config.Configuration) *Server {
 
 	s.mcpServer = mcpServer
 	s.registerTools()
+	s.registerPrompts()
 
 	return s
 }

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -14,16 +14,25 @@ func (s *Server) initTools() []server.ServerTool {
 	return []server.ServerTool{
 		{Tool: mcp.NewTool("whoami",
 			mcp.WithDescription("Get the authenticated account"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
 		), Handler: s.handleWhoami},
 
 		{Tool: mcp.NewTool("get_clusters",
 			mcp.WithDescription("Retrieves the list of clusters"),
 			mcp.WithString("state", mcp.Description("Filter clusters by state (e.g., ready, installing, error)"), mcp.Required()),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
 		), Handler: s.handleGetClusters},
 
 		{Tool: mcp.NewTool("get_cluster",
 			mcp.WithDescription("Retrieves the details of the cluster"),
 			mcp.WithString("cluster_id", mcp.Description("Unique cluster identifier"), mcp.Required()),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
 		), Handler: s.handleGetCluster},
 
 		{Tool: mcp.NewTool("create_rosa_hcp_cluster",
@@ -41,6 +50,9 @@ func (s *Server) initTools() []server.ServerTool {
 			mcp.WithArray("availability_zones", mcp.Description("Array of availability zones for the subnets"), mcp.Required()),
 			mcp.WithString("region", mcp.Description("AWS region"), mcp.DefaultString("us-east-1")),
 			mcp.WithBoolean("multi_arch_enabled", mcp.Description("Enable multi-architecture support"), mcp.DefaultBool(false)),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
 		), Handler: s.handleCreateROSAHCPCluster},
 	}
 }
@@ -54,6 +66,7 @@ func (s *Server) registerTools() {
 	// Register tools using SetTools
 	s.mcpServer.SetTools(tools...)
 }
+
 
 // handleWhoami handles the whoami tool
 func (s *Server) handleWhoami(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
Adds a Prompt resource that guides an AI through guiding a user through pre-reqs and using the values created from pre-reqs in the MCP's rosa hcp cluster install tool.

Also Update README to clarify stdio vs. sse config requirements.