### PR TITLE
Update docs to reflect new tool additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Model Context Protocol (MCP) server for ROSA HCP (Red Hat OpenShift Service on AWS using Hosted Control Planes) written in Go. It enables AI assistants to integrate with Red Hat Managed OpenShift services through 4 core tools: `whoami`, `get_clusters`, `get_cluster`, and `create_rosa_hcp_cluster`.
+This is a Model Context Protocol (MCP) server for ROSA HCP (Red Hat OpenShift Service on AWS using Hosted Control Planes) written in Go. It enables AI assistants to integrate with Red Hat Managed OpenShift services through 5 core tools: `whoami`, `get_clusters`, `get_cluster`, `create_rosa_hcp_cluster`, and `get_rosa_hcp_prerequisites_guide`.
 
 ## Build and Development Commands
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server for ROSA HCP (Red Hat OpenShift Service on
 
 ## Features
 
-- **4 Core Tools**: `whoami`, `get_clusters`, `get_cluster`, `create_rosa_hcp_cluster`
+- **5 Core Tools**: `whoami`, `get_clusters`, `get_cluster`, `create_rosa_hcp_cluster`, `get_rosa_hcp_prerequisites_guide`
 - **Dual Transport Support**: stdio and Server-Sent Events (SSE)
 - **OCM API Integration**: Direct integration with OpenShift Cluster Manager
 - **Multi-Region Support**: Configurable AWS regions (default: us-east-1)
@@ -185,6 +185,15 @@ Provision a new ROSA HCP cluster with required AWS configuration.
     "region": {"type": "string", "default": "us-east-1"},
     "multi_arch_enabled": {"type": "boolean", "default": false}
   }
+}
+```
+
+### 5. get_rosa_hcp_prerequisites_guide
+Get the complete workflow prompt for ROSA HCP cluster installation prerequisites and setup.
+```json
+{
+  "name": "get_rosa_hcp_prerequisites_guide",
+  "description": "Get the complete workflow prompt for ROSA HCP cluster installation prerequisites and setup. Use this workflow to guide a user through the complete setup process for creating a ROSA HCP cluster."
 }
 ```
 


### PR DESCRIPTION
I missed updating the documentation to reflect the new `get_rosa_hcp_preresiquites_guide` tool.